### PR TITLE
First, incomplete attempt at herd-ready litmus-C output

### DIFF
--- a/src/comparator.ml
+++ b/src/comparator.ml
@@ -339,23 +339,30 @@ let main () =
   MyFilename.iter (generate_lit results_dir) xml_dir;
   if !allowset then begin
       printf "Generating litmus files for allow-set.\n%!";
-      MyFilename.iter (generate_lit allow_dir) allow_xml_dir 
+      MyFilename.iter (generate_lit allow_dir) allow_xml_dir
     end;
   MyTime.stop_timer();
 
-  (* 11. Copy to C directory if arch=C. *)
+  (* 11. Also build C witness if arch=C. *)
   if ppc_config.arch = Archs.C then begin
-      MyFilename.iter (fun lit_path ->
-          if Filename.check_suffix lit_path ".litmus" then begin
-              let test_name =
-                Filename.chop_extension (Filename.basename lit_path)
-              in
-              let c_path = MyFilename.concat [c_dir; test_name ^ ".c"] in
-              ignore (Sys.command (sprintf "cp %s %s" lit_path c_path))
-            end
-        ) lit_dir
+      MyTime.start_timer("dump C");
+      printf "Generating C files.\n%!";
+      let generate_c dir xml_file =
+        let all_file = MyFilename.concat [dir; "C"; "@all"] in
+        let test_name = Filename.chop_extension (Filename.basename xml_file) in
+        let c_file = test_name ^ ".c" in
+        let c_path = MyFilename.concat [dir; "C"; c_file] in
+        append_line_to_file all_file c_file;
+        Gen.run xml_file c_path Gen.C ppc_config.arch
+      in
+      MyFilename.iter (generate_c results_dir) xml_dir;
+      if !allowset then begin
+          printf "Generating C files for allow-set.\n%!";
+          MyFilename.iter (generate_c allow_dir) allow_xml_dir
+        end;
+      MyTime.stop_timer();
     end;
- 
+
   (* 12. Show outcome graphically. *)
   if not !batch then
     if nsolutions = 1 then begin

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -173,10 +173,11 @@ let run xml_path out_path out_type arch =
        begin
          (* TODO: share this with the Lit stage? *)
 	 match exec with
-	 | Soln.Single x ->
+	 | Soln.Single x
+           | Soln.Double (x, _, _) ->
+            (* TODO: the double-execution case isn't quite right. *)
 	    let lt = Mk_litmus.litmus_of_execution x in
             fprintf fmtr "%a\n" (Litmus_C.pp name ExecutableC11) lt
-         | _ -> assert false
        end
   end;
   close_out oc

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -148,7 +148,7 @@ let run xml_path out_path out_type arch =
 		let x86_lt = Mk_x86.x86_of_lit name lt in
 		fprintf fmtr "%a\n" Mk_x86.pp x86_lt
              | Archs.C ->
-                fprintf fmtr "%a\n" Litmus_C.pp lt
+                fprintf fmtr "%a\n" (Litmus_C.pp name LitmusC) lt
 	     | _ -> fprintf fmtr "%a\n" Litmus.pp lt)
 	 | Soln.Double (x,y,pi) ->
 	    let lt_src,lt =
@@ -167,12 +167,15 @@ let run xml_path out_path out_type arch =
        end
     | C ->
        assert (Filename.check_suffix out_path ".c");
+       let name =
+         Filename.chop_extension (Filename.basename out_path)
+       in
        begin
          (* TODO: share this with the Lit stage? *)
 	 match exec with
 	 | Soln.Single x ->
 	    let lt = Mk_litmus.litmus_of_execution x in
-            fprintf fmtr "%a\n" Litmus_C.pp lt
+            fprintf fmtr "%a\n" (Litmus_C.pp name ExecutableC11) lt
          | _ -> assert false
        end
   end;

--- a/src/litmus_C.ml
+++ b/src/litmus_C.ml
@@ -178,13 +178,16 @@ let pp oc lt =
     fprintf oc "#endif // NO_PTHREADS\n";
   in
 
+  (* Print an include *)
+  let pp_incl oc = fprintf oc "#include <%s.h>\n" in
+
   (* Include standard headers. *)
   fprintf oc "// Hint: try compiling with gcc -std=c11 <name_of_file.c>\n";
   fprintf oc "\n";
-  fprintf oc "#include <stdio.h>\n";
-  fprintf oc "#include <stdatomic.h>\n";
+  pp_incl oc "stdio";
+  pp_incl oc "stdatomic";
   fprintf oc "\n";
-  if_pthreads (fun () -> fprintf oc "#include <pthread.h>\n");
+  if_pthreads (fun () -> pp_incl oc "pthread");
   fprintf oc "\n";
 
   (* Declare global variables. *)
@@ -202,9 +205,7 @@ let pp oc lt =
   List.iter (fprintf oc "int %a = 0;\n" pp_reg) regs;
   fprintf oc "\n";
 
-  let pp_thd_name oc =
-    fprintf oc "P%d"
-  in
+  let pp_thd_name oc = fprintf oc "P%d" in
 
   (* Print a function for each thread. *)
   let pp_thd tid cs =
@@ -222,9 +223,7 @@ let pp oc lt =
   let pp_pthread_harness () =
     let tids = List.mapi (fun i _ -> i) lt.Litmus.thds in
 
-    let pp_thd_wrapper_name oc =
-      fprintf oc "thread%d"
-    in
+    let pp_thd_wrapper_name oc = fprintf oc "thread%d" in
 
     (* Print a pthread thread stub for each thread. *)
     let pp_thd_wrapper tid =

--- a/src/litmus_C.ml
+++ b/src/litmus_C.ml
@@ -297,11 +297,15 @@ let pp name dialect oc lt =
   if registers_global_in dialect
   then
     begin
-      fprintf oc "// Declaring thread-local variables at global scope\n";
-      fprintf oc "// so they can be checked in the postcondition.\n";
-      let regs = List.fold_left (List.fold_left extract_regs) [] lt.Litmus.thds in
-      pp_regs dialect oc 0 regs;
-      nl oc
+      match (List.fold_left (List.fold_left extract_regs) [] lt.Litmus.thds) with
+      | [] -> ()
+      | regs ->
+         begin
+           fprintf oc "// Declaring thread-local variables at global scope\n";
+           fprintf oc "// so they can be checked in the postcondition.\n";
+           pp_regs dialect oc 0 regs;
+           nl oc
+         end;
     end;
 
   (* Print the argument vector for a thread function. *)


### PR DESCRIPTION
**This is a fairly hairy change set, and will likely need some fixing up before it's merge-ready.  See caveats and example below.**

This pull request splits gen's `-Tlit` output mode into two:
* `-Tc`, which outputs an executable C witness using pthreads (like `-Tlit` used to do for the C architecture);
* `-Tlit` proper, which now outputs a litmus test that (in most cases) can be investigated by `herd7`.

Both of these modes use the same C pretty-printer, which is now aware of the differences between a litmus test and an executable witness and emits different code accordingly.  Such differences include:

* only emitting `pthreads` code in `-Tc` (and, even then, it gets surrounded by `#ifndef` guards to allow it to be removed eg. to build cleaner assembly output for investigating the witness);
* emitting registers thread-locally in `-Tlit`, and globally in `-Tc`;
* emitting a litmus postcondition in `-Tlit`, and a `main()` in `-Tc`;
* passing globals by pointer in `-Tlit`, and just using normal global variables in `-Tc` (complete with adding or removing `*` and `&` as needed);
* emitting a litmus init block in `-Tlit`, instead of the init code used in `-Tc`.

The comparator has also been changed to match: instead of emitting `-Tlit` into `/litmus` and copying it to `/C`, it now emits `-Tlit` into `/litmus` and `-Tc` into `/c`.  Anything that was expecting a compilable C program in `/litmus` _will break_!

Some known caveats include:

- I don't translate CAS properly in litmus, as it'll need either changes upstream in herd to allow `&`, or fairly hairy register shuffling to turn registers into pointers;
- Some tests are coming back with the `*undef*` flag in herd7, though this might be expected (I don't know enough about undefined behaviour to tell for sure);
- Some tests are coming back with positive witnesses, and I can't tell whether this is due to discrepancies between C11 models or genuine bugs in the litmus pretty-printer (I can't see anything _obviously_ wrong...)
- The internal litmus syntax tree gets generated twice: once for `-Tlit`, and once for `-Tc`;
- Stylistic and formatting issues (I'm learning OCaml while I go XD);
- The `-Tlit` init block might be redundant, as it sets everything to `0`;
- I'm not sure if I'm handling the distinction between atomic and non-atomic locations properly in the translation to litmus.  This might be the cause of some `*undef*`s.
- It might be better to just not emit pthreads code if not needed, instead of `ifndef`ing it.  This'll need a bit of user interface changing, though.  We could then also telescope the thread functions back into one function per thread.

And now a possibly surprising example.  First, the C witness:

```c
// Hint: try compiling with gcc -std=c11 <test_0.c>

#include <stdio.h>
#include <stdatomic.h>

#ifndef NO_PTHREADS
#include <pthread.h>
#endif // NO_PTHREADS

// Declaring global variables.
atomic_int x = ATOMIC_VAR_INIT(0);
atomic_int y = ATOMIC_VAR_INIT(0);

// Declaring thread-local variables at global scope
// so they can be checked in the postcondition.
int t1r0 = 0;
int t0r0 = 0;

// Thread 0
void P0() {
  t0r0 = atomic_load_explicit(&y, memory_order_relaxed);
  atomic_store_explicit(&x, 1, memory_order_relaxed);
}

// Thread 1
void P1() {
  t1r0 = atomic_load_explicit(&x, memory_order_relaxed);
  atomic_store_explicit(&y, 1, memory_order_relaxed);
}

#ifndef NO_PTHREADS
// Thread 0: pthread wrapper
void *thread0(void *unused) {
  P0();
  pthread_exit(0);
}

// Thread 1: pthread wrapper
void *thread1(void *unused) {
  P1();
  pthread_exit(0);
}

int main() {

  // Declaring thread-id variables.
  pthread_t tid0;
  pthread_t tid1;

  // Launching threads.
  pthread_create(&tid0, NULL, thread0, NULL);
  pthread_create(&tid1, NULL, thread1, NULL);

  // Joining threads.
  pthread_join(tid0, NULL);
  pthread_join(tid1, NULL);

  int result = t0r0 == 1 && t1r0 == 1 && x == 1 && y == 1;
  printf("Result: %d\n", result);
  return (result);

}
#endif // NO_PTHREADS
```

Litmus:
```c
C test_0
// Hint: try simulating with herd7 <test_0.litmus>
// WARNING: C litmus output is experimental!

// Declaring global variables.
{
  x = 0;
  y = 0;
}

// Thread 0
void P0(atomic_int *x, atomic_int *y) {
  int r0 = 0;

  r0 = atomic_load_explicit(y, memory_order_relaxed);
  atomic_store_explicit(x, 1, memory_order_relaxed);
}

// Thread 1
void P1(atomic_int *x, atomic_int *y) {
  int r0 = 0;

  r0 = atomic_load_explicit(x, memory_order_relaxed);
  atomic_store_explicit(y, 1, memory_order_relaxed);
}

exists (0:r0 == 1 /\ 1:r0 == 1 /\ x == 1 /\ y == 1)
```

Results from `herd7 -c11`:

```
Test test_0 Allowed
States 4
0:r0=0; 1:r0=0; x=1; y=1;
0:r0=0; 1:r0=1; x=1; y=1;
0:r0=1; 1:r0=0; x=1; y=1;
0:r0=1; 1:r0=1; x=1; y=1;
Ok
Witnesses
Positive: 1 Negative: 3
Condition exists (0:r0=1 /\ 1:r0=1 /\ x=1 /\ y=1)
Observation test_0 Sometimes 1 3
Time test_0 0.01
Hash=5dbeba3dbf1d030d68a978a4ca38eced
```

Hmm.