### PR TITLE
Track register in Litmus CAS

### DIFF
--- a/src/litmus.ml
+++ b/src/litmus.ml
@@ -63,7 +63,7 @@ type instruction =
   | LoadLink of Register.t * MyLocation.t expr * Value.t * Value.t expr
   | Store of MyLocation.t expr * Value.t expr
   | StoreCnd of MyLocation.t expr * Value.t expr
-  | Cas of MyLocation.t expr * Value.t * Value.t expr
+  | Cas of Register.t option * MyLocation.t expr * Value.t * Value.t expr
   | Fence
 
 (** Simple pretty-printing of attributes (for debugging) *)
@@ -90,10 +90,18 @@ let pp_instr oc = function
      fprintf oc "sc(%a,%a%a)"
 	     (pp_expr MyLocation.pp) le (pp_expr Value.pp) ve
              pp_attrs attrs
-  | Cas (le,v,ve), attrs ->
-     fprintf oc "cas(%a,%a,%a%a)"
+  | Cas (None,le,v,ve), attrs ->
+     fprintf oc "cas(?,%a,%a,%a%a)"
              (pp_expr MyLocation.pp) le Value.pp v (pp_expr Value.pp) ve
              pp_attrs attrs
+  | Cas (Some r,le,v,ve), attrs ->
+     fprintf oc "cas(%a,%a,%a,%a%a)"
+             Register.pp r
+             (pp_expr MyLocation.pp) le
+             Value.pp v
+             (pp_expr Value.pp) ve
+             pp_attrs attrs
+
   | Fence, attrs ->
      fprintf oc "fence(%a)"
 	     (MyList.pp_gen "" (fun oc -> fprintf oc ",%s")) attrs

--- a/src/litmus_OpenCL.ml
+++ b/src/litmus_OpenCL.ml
@@ -103,10 +103,10 @@ let pp_instr pp_loc oc = function
         to avoid throwing off the indentation. *)
      fprintf oc "// elided store-conditional instruction"
 
-  | Litmus.Cas (obj,exp,des), attrs ->
+  | Litmus.Cas (r,obj,exp,des), attrs ->
      let mo = Litmus_C.get_mo attrs in
      let ms = get_ms attrs in
-     pp_cas pp_loc oc mo ms obj None exp des
+     pp_cas pp_loc oc mo ms obj r exp des
     
   | Litmus.Fence, attrs ->
      let mo = Litmus_C.get_mo attrs in
@@ -140,7 +140,7 @@ let partition_locs_in_instr s (a_locs, na_locs) = function
   | Litmus.LoadLink (_,le,_,_), attrs
   | Litmus.Store (le,_), attrs
   | Litmus.StoreCnd (le,_), attrs
-  | Litmus.Cas (le,_,_), attrs ->
+  | Litmus.Cas (_,le,_,_), attrs ->
      let l = Litmus.expr_base_of le in
      begin match List.mem s attrs with
      | true ->

--- a/src/mk_litmus.ml
+++ b/src/mk_litmus.ml
@@ -57,7 +57,10 @@ let mk_instr x maps reg_map e =
        let rval = List.assoc e maps.Exec.rval_map in
        let wval = List.assoc e maps.Exec.wval_map in
        let wval_expr = Litmus.mk_expr wval d_regs in
-       Litmus.Cas (loc_expr, rval, wval_expr)
+       (* Some CAS events spill their expected value into a register,
+          but this isn't guaranteed. *)
+       let reg = List.assoc_opt e reg_map in
+       Litmus.Cas (reg, loc_expr, rval, wval_expr)
     | true, false, false ->
        let reg = reg_of e in
        let loc = List.assoc e maps.Exec.loc_map in


### PR DESCRIPTION
In at least some cases (eg in C11 partialSC), R+W events have a register associated with them, and that register feeds into the forbidden execution.  For instance, one such event structure is (mind my ASCII):

```
[RMW x=0 -> x=1] --co-> [RMW x=0 -> x=2]
```

In this case, both RMWs store the read value to `r0`, because the witnessing C execution is `(0:r0 = 0 /\ 1:r0 = 0 /\ x=2)`.
However, at the moment, this register is thrown away at the Litmus level and replaced with a temporary `expected` value, with the postcondition just pointing to a dangling `r0` (or, on `master`, not mentioning those registers at all).

This is an attempt to push those registers through the Litmus IR and into the pretty-printer for C.  I've assumed that there still exist possibilities where the RMW does *not* spill to a register, so I've extended the `Cas(...)` variant with
an *optional* register, and kept the old logic around for when this is `None`.

I'm not sure if this change adversely affects other CAS instances eg. on other models, so there might need to be some further work needed; for this reason and because there are issues with `master` not propagating the registers through (not sure why not), this is targeting `dev`.

Example output for above event structure before changes:

```c
C test_2
// Hint: try simulating with herd7 <test_2.litmus>
// WARNING: C litmus output is experimental!

// Declaring global variables.
{
  x = 0;
}

// Thread 0
void P0(atomic_int *x) {
  int expected;
  expected = 0; /* returns bool */ atomic_compare_exchange_strong_explicit(x, &expected, 1, memory_order_relaxed, memory_order_relaxed);
}

// Thread 1
void P1(atomic_int *x) {
  int expected;
  expected = 0; /* returns bool */ atomic_compare_exchange_strong_explicit(x, &expected, 2, memory_order_relaxed, memory_order_relaxed);
}

exists (0:r0 == 0 /\ 1:r0 == 0 /\ x == 2)
```

The postcondition here is right, but it refers to `r0` instead of `expected` (the default variable introduced when there is no register for a CAS).  (The current `master` version of Memalloy gives us `exists (x == 2)`, which is clearly too general; as mentioned before, when I've tried to apply this change there, the event registers haven't been available and there's no change)

And after:

```c
C test_2
// Hint: try simulating with herd7 <test_2.litmus>
// WARNING: C litmus output is experimental!

// Declaring global variables.
{
  x = 0;
}

// Thread 0
void P0(atomic_int *x) {
  int r0 = 0;

  r0 = 0; /* returns bool */ atomic_compare_exchange_strong_explicit(x, &r0, 1, memory_order_relaxed, memory_order_relaxed);
}

// Thread 1
void P1(atomic_int *x) {
  int r0 = 0;

  r0 = 0; /* returns bool */ atomic_compare_exchange_strong_explicit(x, &r0, 2, memory_order_relaxed, memory_order_relaxed);
}

exists (0:r0 == 0 /\ 1:r0 == 0 /\ x == 2)
```